### PR TITLE
fix - logic flipped in zicond

### DIFF
--- a/coretp/isa/instructions/crypto.py
+++ b/coretp/isa/instructions/crypto.py
@@ -8,7 +8,7 @@ from coretp.rv_enums import OperandType
 
 andn = InstructionDef(
     name="andn",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -22,7 +22,7 @@ andn = InstructionDef(
 
 orn = InstructionDef(
     name="orn",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -36,7 +36,7 @@ orn = InstructionDef(
 
 rol = InstructionDef(
     name="rol",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -50,7 +50,7 @@ rol = InstructionDef(
 
 ror = InstructionDef(
     name="ror",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -64,7 +64,7 @@ ror = InstructionDef(
 
 xnor = InstructionDef(
     name="xnor",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -78,7 +78,7 @@ xnor = InstructionDef(
 
 brev8 = InstructionDef(
     name="brev8",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN32,
     category=Category.CONTROL,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -119,7 +119,7 @@ packh = InstructionDef(
 
 clmul = InstructionDef(
     name="clmul",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKC | Extension.ZBC,
+    extension=Extension.ZBKC,
     xlen=Xlen.XLEN32,
     category=Category.ARITHMETIC,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -133,7 +133,7 @@ clmul = InstructionDef(
 
 clmulh = InstructionDef(
     name="clmulh",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKC | Extension.ZBC,
+    extension=Extension.ZBKC,
     xlen=Xlen.XLEN32,
     category=Category.ARITHMETIC,
     destination=OperandSlot("rd", OperandType.GPR),
@@ -990,7 +990,7 @@ aes64ks2 = InstructionDef(
 
 rev8 = InstructionDef(
     name="rev8",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN64,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -1003,7 +1003,7 @@ rev8 = InstructionDef(
 
 rev8_rv32 = InstructionDef(
     name="rev8.rv32",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB | Extension.ZBB,
     xlen=Xlen.XLEN32,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -1016,7 +1016,7 @@ rev8_rv32 = InstructionDef(
 
 rolw = InstructionDef(
     name="rolw",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN64,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -1030,7 +1030,7 @@ rolw = InstructionDef(
 
 rori = InstructionDef(
     name="rori",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN64,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -1044,7 +1044,7 @@ rori = InstructionDef(
 
 roriw = InstructionDef(
     name="roriw",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN64,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),
@@ -1058,7 +1058,7 @@ roriw = InstructionDef(
 
 rorw = InstructionDef(
     name="rorw",
-    extension=Extension.ZKS | Extension.ZKN | Extension.ZK | Extension.ZBKB | Extension.ZBB,
+    extension=Extension.ZBKB,
     xlen=Xlen.XLEN64,
     category=Category.LOGIC,
     destination=OperandSlot(name="rd", type=OperandType.GPR),

--- a/coretp/plans/zicond/zicond_scenarios.py
+++ b/coretp/plans/zicond/zicond_scenarios.py
@@ -884,9 +884,9 @@ def SID_EXCEP_04_2_1_MUX_SELECT_0():
     selector = LoadImmediateStep(imm=0)  # 0 = select input0, non-zero = select input1
 
     # If selector == 0: use input0, else use 0
-    selected_input0 = Arithmetic(op="czero.eqz", src1=input0, src2=selector)
+    selected_input0 = Arithmetic(op="czero.nez", src1=input0, src2=selector)
     # If selector != 0: use input1, else use 0
-    selected_input1 = Arithmetic(op="czero.nez", src1=input1, src2=selector)
+    selected_input1 = Arithmetic(op="czero.eqz", src1=input1, src2=selector)
 
     # Combine the selections (only one will be non-zero)
     mux_output = Arithmetic(op="or", src1=selected_input0, src2=selected_input1)
@@ -924,13 +924,13 @@ def SID_EXCEP_04_2_1_MUX_SELECT_1():
     input1 = LoadImmediateStep(imm=0xBEEF)
     selector = LoadImmediateStep(imm=1)  # non-zero = select input1, 0 = select input0
 
-    # If selector == 0: use input0, else use 0
-    selected_input0 = Arithmetic(op="czero.eqz", src1=input0, src2=selector)
     # If selector != 0: use input1, else use 0
-    selected_input1 = Arithmetic(op="czero.nez", src1=input1, src2=selector)
+    selected_input1 = Arithmetic(op="czero.nez", src1=input0, src2=selector)
+    # If selector == 0: use input0, else use 0
+    selected_input0 = Arithmetic(op="czero.eqz", src1=input1, src2=selector)
 
     # Combine the selections (only one will be non-zero)
-    mux_output = Arithmetic(op="or", src1=selected_input0, src2=selected_input1)
+    mux_output = Arithmetic(op="or", src1=selected_input1, src2=selected_input0)
 
     # Expected result: since selector=1 (non-zero), should get input1=0xBEEF
     expected = LoadImmediateStep(imm=0xBEEF)
@@ -945,8 +945,8 @@ def SID_EXCEP_04_2_1_MUX_SELECT_1():
             input0,
             input1,
             selector,
-            selected_input0,
-            selected_input1,
+            selected_input0,  # Swapped order
+            selected_input1,  # Swapped order
             mux_output,
             expected,
             assert_equal,

--- a/coretp/plans/zicond/zicond_scenarios.py
+++ b/coretp/plans/zicond/zicond_scenarios.py
@@ -11,30 +11,32 @@ from . import zicond_scenario
 @zicond_scenario
 def SID_EXCEP_01_EQZ_RS1_NZ():
     """
-    Test czero.eqz instruction where RS1 is zero and RS2 is non-zero.
-    Expected: result should equal the check value (RS1).
+    Test czero.eqz instruction where RS1 is non-zero and RS2 is zero.
+    Expected: result should be zero (condition met).
     """
-    # Load immediate value 0 into li
+    # Load immediate value 0 into li (rs2)
     li = LoadImmediateStep(imm=0)
 
-    # Load immediate check value 0xc0ffee
+    # Load immediate check value 0xc0ffee (rs1)
     check_val = LoadImmediateStep(imm=0xC0FFEE)
 
-    # Execute czero.eqz operation: if src2 (li) == 0, return src1 (check_val), else return 0
+    # Execute czero.eqz operation: if src2 (li) == 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.eqz", src1=check_val, src2=li)
 
-    # Assert that the result equals check_val
-    assert_equal = AssertEqual(src1=czero, src2=check_val)
+    # Expected result: since rs2=0, should get 0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="1",
         name="SID_EXCEP_01_EQZ_RS1_NZ",
-        description="Test czero.eqz instruction where RS1 is zero and RS2 is non-zero",
+        description="Test czero.eqz instruction where RS1 is non-zero and RS2 is zero",
         env=TestEnvCfg(),
         steps=[
             li,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -44,19 +46,20 @@ def SID_EXCEP_01_EQZ_RS1_NZ():
 def SID_EXCEP_01_EQZ_RS1_Z():
     """
     Test czero.eqz instruction where both RS1 and RS2 are zero.
-    Expected: result should equal the check value (0).
+    Expected: result should be zero (condition met).
     """
-    # Load immediate value 0 into li
+    # Load immediate value 0 into li (rs2)
     li = LoadImmediateStep(imm=0)
 
-    # Load immediate check value 0
+    # Load immediate check value 0 (rs1)
     check_val = LoadImmediateStep(imm=0)
 
-    # Execute czero.eqz operation: if src2 (li) == 0, return src1 (check_val), else return 0
+    # Execute czero.eqz operation: if src2 (li) == 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.eqz", src1=check_val, src2=li)
 
-    # Assert that the result equals check_val
-    assert_equal = AssertEqual(src1=czero, src2=check_val)
+    # Expected result: since rs2=0, should get 0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="2",
@@ -67,6 +70,7 @@ def SID_EXCEP_01_EQZ_RS1_Z():
             li,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -76,19 +80,20 @@ def SID_EXCEP_01_EQZ_RS1_Z():
 def SID_EXCEP_01_NEZ_RS1_NZ():
     """
     Test czero.nez instruction where both RS1 and RS2 are non-zero.
-    Expected: result should equal the check value (RS1).
+    Expected: result should be zero (condition met).
     """
-    # Load immediate value 0xdeadbeef into li
+    # Load immediate value 0xdeadbeef into li (rs2)
     li = LoadImmediateStep(imm=0xDEADBEEF)
 
-    # Load immediate check value 0xc0ffee
+    # Load immediate check value 0xc0ffee (rs1)
     check_val = LoadImmediateStep(imm=0xC0FFEE)
 
-    # Execute czero.nez operation: if src2 (li) != 0, return src1 (check_val), else return 0
+    # Execute czero.nez operation: if src2 (li) != 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.nez", src1=check_val, src2=li)
 
-    # Assert that the result equals check_val
-    assert_equal = AssertEqual(src1=czero, src2=check_val)
+    # Expected result: since rs2!=0, should get 0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="3",
@@ -99,6 +104,7 @@ def SID_EXCEP_01_NEZ_RS1_NZ():
             li,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -108,19 +114,20 @@ def SID_EXCEP_01_NEZ_RS1_NZ():
 def SID_EXCEP_01_NEZ_RS1_Z():
     """
     Test czero.nez instruction where RS1 is zero and RS2 is non-zero.
-    Expected: result should equal the check value (0).
+    Expected: result should be zero (condition met).
     """
-    # Load immediate value 0xdeadbeef into li
+    # Load immediate value 0xdeadbeef into li (rs2)
     li = LoadImmediateStep(imm=0xDEADBEEF)
 
-    # Load immediate check value 0
+    # Load immediate check value 0 (rs1)
     check_val = LoadImmediateStep(imm=0)
 
-    # Execute czero.nez operation: if src2 (li) != 0, return src1 (check_val), else return 0
+    # Execute czero.nez operation: if src2 (li) != 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.nez", src1=check_val, src2=li)
 
-    # Assert that the result equals check_val
-    assert_equal = AssertEqual(src1=czero, src2=check_val)
+    # Expected result: since rs2!=0, should get 0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="4",
@@ -131,6 +138,7 @@ def SID_EXCEP_01_NEZ_RS1_Z():
             li,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -140,22 +148,20 @@ def SID_EXCEP_01_NEZ_RS1_Z():
 def SID_EXCEP_02_EQZ_RS1_NZ():
     """
     Test czero.eqz instruction where RS1 is non-zero and RS2 is non-zero.
-    Expected: result should be zero (condition not met).
+    Expected: result should equal RS1 (condition not met).
     """
-    # Load immediate value 0xdeadbeef into li
+    # Load immediate value 0xdeadbeef into li (rs2)
     li = LoadImmediateStep(imm=0xDEADBEEF)
 
-    # Load immediate zero value for comparison
-    zero_val = LoadImmediateStep(imm=0)
-
-    # Load immediate check value 0xc0ffee
+    # Load immediate check value 0xc0ffee (rs1)
     check_val = LoadImmediateStep(imm=0xC0FFEE)
 
-    # Execute czero.eqz operation: if src2 (li) == 0, return src1 (check_val), else return 0
+    # Execute czero.eqz operation: if src2 (li) == 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.eqz", src1=check_val, src2=li)
 
-    # Assert that the result equals zero_val (0)
-    assert_equal = AssertEqual(src1=czero, src2=zero_val)
+    # Expected result: since rs2!=0, should get rs1=0xC0FFEE
+    expected = LoadImmediateStep(imm=0xC0FFEE)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="5",
@@ -164,9 +170,9 @@ def SID_EXCEP_02_EQZ_RS1_NZ():
         env=TestEnvCfg(),
         steps=[
             li,
-            zero_val,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -176,22 +182,20 @@ def SID_EXCEP_02_EQZ_RS1_NZ():
 def SID_EXCEP_02_EQZ_RS1_Z():
     """
     Test czero.eqz instruction where RS1 is zero and RS2 is non-zero.
-    Expected: result should be zero (condition not met).
+    Expected: result should equal RS1 (condition not met).
     """
-    # Load immediate value 0xdeadbeef into li
+    # Load immediate value 0xdeadbeef into li (rs2)
     li = LoadImmediateStep(imm=0xDEADBEEF)
 
-    # Load immediate zero value for comparison
-    zero_val = LoadImmediateStep(imm=0)
-
-    # Load immediate check value 0 (same as zero_val)
+    # Load immediate check value 0 (rs1)
     check_val = LoadImmediateStep(imm=0)
 
-    # Execute czero.eqz operation: if src2 (li) == 0, return src1 (check_val), else return 0
+    # Execute czero.eqz operation: if src2 (li) == 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.eqz", src1=check_val, src2=li)
 
-    # Assert that the result equals zero_val (0)
-    assert_equal = AssertEqual(src1=czero, src2=zero_val)
+    # Expected result: since rs2!=0, should get rs1=0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="6",
@@ -200,9 +204,9 @@ def SID_EXCEP_02_EQZ_RS1_Z():
         env=TestEnvCfg(),
         steps=[
             li,
-            zero_val,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -212,22 +216,20 @@ def SID_EXCEP_02_EQZ_RS1_Z():
 def SID_EXCEP_02_NEZ_RS1_Z():
     """
     Test czero.nez instruction where RS1 is non-zero and RS2 is zero.
-    Expected: result should be zero (condition not met).
+    Expected: result should equal RS1 (condition not met).
     """
-    # Load immediate value 0 into li
+    # Load immediate value 0 into li (rs2)
     li = LoadImmediateStep(imm=0)
 
-    # Load immediate zero value for comparison
-    zero_val = LoadImmediateStep(imm=0)
-
-    # Load immediate check value 0xc0ffee
+    # Load immediate check value 0xc0ffee (rs1)
     check_val = LoadImmediateStep(imm=0xC0FFEE)
 
-    # Execute czero.nez operation: if src2 (li) != 0, return src1 (check_val), else return 0
+    # Execute czero.nez operation: if src2 (li) != 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.nez", src1=check_val, src2=li)
 
-    # Assert that the result equals zero_val (0)
-    assert_equal = AssertEqual(src1=czero, src2=zero_val)
+    # Expected result: since rs2=0, should get rs1=0xC0FFEE
+    expected = LoadImmediateStep(imm=0xC0FFEE)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="7",
@@ -236,9 +238,9 @@ def SID_EXCEP_02_NEZ_RS1_Z():
         env=TestEnvCfg(),
         steps=[
             li,
-            zero_val,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -248,22 +250,20 @@ def SID_EXCEP_02_NEZ_RS1_Z():
 def SID_EXCEP_02_NEZ_RS1_NZ():
     """
     Test czero.nez instruction where both RS1 and RS2 are zero.
-    Expected: result should be zero (condition not met).
+    Expected: result should equal RS1 (condition not met).
     """
-    # Load immediate value 0 into li
+    # Load immediate value 0 into li (rs2)
     li = LoadImmediateStep(imm=0)
 
-    # Load immediate zero value for comparison
-    zero_val = LoadImmediateStep(imm=0)
-
-    # Load immediate check value 0 (same as zero_val)
+    # Load immediate check value 0 (rs1)
     check_val = LoadImmediateStep(imm=0)
 
-    # Execute czero.nez operation: if src2 (li) != 0, return src1 (check_val), else return 0
+    # Execute czero.nez operation: if src2 (li) != 0, return 0, else return src1 (check_val)
     czero = Arithmetic(op="czero.nez", src1=check_val, src2=li)
 
-    # Assert that the result equals zero_val (0)
-    assert_equal = AssertEqual(src1=czero, src2=zero_val)
+    # Expected result: since rs2=0, should get rs1=0
+    expected = LoadImmediateStep(imm=0)
+    assert_equal = AssertEqual(src1=czero, src2=expected)
 
     return TestScenario.from_steps(
         id="8",
@@ -272,9 +272,9 @@ def SID_EXCEP_02_NEZ_RS1_NZ():
         env=TestEnvCfg(),
         steps=[
             li,
-            zero_val,
             check_val,
             czero,
+            expected,
             assert_equal,
         ],
     )
@@ -283,27 +283,27 @@ def SID_EXCEP_02_NEZ_RS1_NZ():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_PASSING_ADD():
     """
-    Test czero.eqz with condition=0 (passes) - selects ADD result.
+    Test czero.eqz with condition=0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should pass
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should return 0
 
     # Compute add operation
     add_result = Arithmetic(op="add", src1=a_val, src2=b_val)  # 10 + 3 = 13
 
-    # Use czero.eqz: if condition == 0, return add_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return add_result
     selected_add = Arithmetic(op="czero.eqz", src1=add_result, src2=condition)
 
-    # Expected result: since condition=0, should get add_result=13
-    expected = LoadImmediateStep(imm=13)
+    # Expected result: since condition=0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_add, src2=expected)
 
     return TestScenario.from_steps(
         id="9",
         name="SID_EXCEP_04_EQZ_PASSING_ADD",
-        description="Test czero.eqz with condition=0 (passes) - selects ADD result",
+        description="Test czero.eqz with condition=0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -320,27 +320,27 @@ def SID_EXCEP_04_EQZ_PASSING_ADD():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_FAILING_ADD():
     """
-    Test czero.eqz with condition≠0 (fails) - returns 0.
+    Test czero.eqz with condition≠0 (fails) - returns ADD result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should fail
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should return rs1
 
     # Compute add operation
     add_result = Arithmetic(op="add", src1=a_val, src2=b_val)  # 10 + 3 = 13
 
-    # Use czero.eqz: if condition == 0, return add_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return add_result
     selected_add = Arithmetic(op="czero.eqz", src1=add_result, src2=condition)
 
-    # Expected result: since condition≠0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition≠0, should get add_result=13
+    expected = LoadImmediateStep(imm=13)
     assert_equal = AssertEqual(src1=selected_add, src2=expected)
 
     return TestScenario.from_steps(
         id="10",
         name="SID_EXCEP_04_EQZ_FAILING_ADD",
-        description="Test czero.eqz with condition≠0 (fails) - returns 0",
+        description="Test czero.eqz with condition≠0 (fails) - returns ADD result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -357,27 +357,27 @@ def SID_EXCEP_04_EQZ_FAILING_ADD():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_PASSING_SUB():
     """
-    Test czero.nez with condition≠0 (passes) - selects SUB result.
+    Test czero.nez with condition≠0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should pass
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should return 0
 
     # Compute sub operation
     sub_result = Arithmetic(op="sub", src1=a_val, src2=b_val)  # 10 - 3 = 7
 
-    # Use czero.nez: if condition != 0, return sub_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return sub_result
     selected_sub = Arithmetic(op="czero.nez", src1=sub_result, src2=condition)
 
-    # Expected result: since condition≠0, should get sub_result=7
-    expected = LoadImmediateStep(imm=7)
+    # Expected result: since condition≠0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_sub, src2=expected)
 
     return TestScenario.from_steps(
         id="11",
         name="SID_EXCEP_04_NEZ_PASSING_SUB",
-        description="Test czero.nez with condition≠0 (passes) - selects SUB result",
+        description="Test czero.nez with condition≠0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -394,27 +394,27 @@ def SID_EXCEP_04_NEZ_PASSING_SUB():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_FAILING_SUB():
     """
-    Test czero.nez with condition=0 (fails) - returns 0.
+    Test czero.nez with condition=0 (fails) - returns SUB result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should fail
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should return rs1
 
     # Compute sub operation
     sub_result = Arithmetic(op="sub", src1=a_val, src2=b_val)  # 10 - 3 = 7
 
-    # Use czero.nez: if condition != 0, return sub_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return sub_result
     selected_sub = Arithmetic(op="czero.nez", src1=sub_result, src2=condition)
 
-    # Expected result: since condition=0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition=0, should get sub_result=7
+    expected = LoadImmediateStep(imm=7)
     assert_equal = AssertEqual(src1=selected_sub, src2=expected)
 
     return TestScenario.from_steps(
         id="12",
         name="SID_EXCEP_04_NEZ_FAILING_SUB",
-        description="Test czero.nez with condition=0 (fails) - returns 0",
+        description="Test czero.nez with condition=0 (fails) - returns SUB result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -431,27 +431,27 @@ def SID_EXCEP_04_NEZ_FAILING_SUB():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_PASSING_SUB():
     """
-    Test czero.eqz with condition=0 (passes) - selects SUB result.
+    Test czero.eqz with condition=0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should pass
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should return 0
 
     # Compute sub operation
     sub_result = Arithmetic(op="sub", src1=a_val, src2=b_val)  # 10 - 3 = 7
 
-    # Use czero.eqz: if condition == 0, return sub_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return sub_result
     selected_sub = Arithmetic(op="czero.eqz", src1=sub_result, src2=condition)
 
-    # Expected result: since condition=0, should get sub_result=7
-    expected = LoadImmediateStep(imm=7)
+    # Expected result: since condition=0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_sub, src2=expected)
 
     return TestScenario.from_steps(
         id="13",
         name="SID_EXCEP_04_EQZ_PASSING_SUB",
-        description="Test czero.eqz with condition=0 (passes) - selects SUB result",
+        description="Test czero.eqz with condition=0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -468,27 +468,27 @@ def SID_EXCEP_04_EQZ_PASSING_SUB():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_FAILING_SUB():
     """
-    Test czero.eqz with condition≠0 (fails) - returns 0.
+    Test czero.eqz with condition≠0 (fails) - returns SUB result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should fail
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should return rs1
 
     # Compute sub operation
     sub_result = Arithmetic(op="sub", src1=a_val, src2=b_val)  # 10 - 3 = 7
 
-    # Use czero.eqz: if condition == 0, return sub_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return sub_result
     selected_sub = Arithmetic(op="czero.eqz", src1=sub_result, src2=condition)
 
-    # Expected result: since condition≠0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition≠0, should get sub_result=7
+    expected = LoadImmediateStep(imm=7)
     assert_equal = AssertEqual(src1=selected_sub, src2=expected)
 
     return TestScenario.from_steps(
         id="14",
         name="SID_EXCEP_04_EQZ_FAILING_SUB",
-        description="Test czero.eqz with condition≠0 (fails) - returns 0",
+        description="Test czero.eqz with condition≠0 (fails) - returns SUB result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -505,27 +505,27 @@ def SID_EXCEP_04_EQZ_FAILING_SUB():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_PASSING_ADD():
     """
-    Test czero.nez with condition≠0 (passes) - selects ADD result.
+    Test czero.nez with condition≠0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should pass
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should return 0
 
     # Compute add operation
     add_result = Arithmetic(op="add", src1=a_val, src2=b_val)  # 10 + 3 = 13
 
-    # Use czero.nez: if condition != 0, return add_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return add_result
     selected_add = Arithmetic(op="czero.nez", src1=add_result, src2=condition)
 
-    # Expected result: since condition≠0, should get add_result=13
-    expected = LoadImmediateStep(imm=13)
+    # Expected result: since condition≠0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_add, src2=expected)
 
     return TestScenario.from_steps(
         id="15",
         name="SID_EXCEP_04_NEZ_PASSING_ADD",
-        description="Test czero.nez with condition≠0 (passes) - selects ADD result",
+        description="Test czero.nez with condition≠0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -542,27 +542,27 @@ def SID_EXCEP_04_NEZ_PASSING_ADD():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_FAILING_ADD():
     """
-    Test czero.nez with condition=0 (fails) - returns 0.
+    Test czero.nez with condition=0 (fails) - returns ADD result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=10)
     b_val = LoadImmediateStep(imm=3)
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should fail
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should return rs1
 
     # Compute add operation
     add_result = Arithmetic(op="add", src1=a_val, src2=b_val)  # 10 + 3 = 13
 
-    # Use czero.nez: if condition != 0, return add_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return add_result
     selected_add = Arithmetic(op="czero.nez", src1=add_result, src2=condition)
 
-    # Expected result: since condition=0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition=0, should get add_result=13
+    expected = LoadImmediateStep(imm=13)
     assert_equal = AssertEqual(src1=selected_add, src2=expected)
 
     return TestScenario.from_steps(
         id="16",
         name="SID_EXCEP_04_NEZ_FAILING_ADD",
-        description="Test czero.nez with condition=0 (fails) - returns 0",
+        description="Test czero.nez with condition=0 (fails) - returns ADD result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -579,27 +579,27 @@ def SID_EXCEP_04_NEZ_FAILING_ADD():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_PASSING_AND():
     """
-    Test czero.eqz with condition=0 (passes) - selects AND result.
+    Test czero.eqz with condition=0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should pass
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should return 0
 
     # Compute and operation
     and_result = Arithmetic(op="and", src1=a_val, src2=b_val)  # 0xF0 & 0xAA = 0xA0
 
-    # Use czero.eqz: if condition == 0, return and_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return and_result
     selected_and = Arithmetic(op="czero.eqz", src1=and_result, src2=condition)
 
-    # Expected result: since condition=0, should get and_result=0xA0
-    expected = LoadImmediateStep(imm=0xA0)
+    # Expected result: since condition=0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_and, src2=expected)
 
     return TestScenario.from_steps(
         id="17",
         name="SID_EXCEP_04_EQZ_PASSING_AND",
-        description="Test czero.eqz with condition=0 (passes) - selects AND result",
+        description="Test czero.eqz with condition=0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -616,27 +616,27 @@ def SID_EXCEP_04_EQZ_PASSING_AND():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_FAILING_AND():
     """
-    Test czero.eqz with condition≠0 (fails) - returns 0.
+    Test czero.eqz with condition≠0 (fails) - returns AND result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should fail
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should return rs1
 
     # Compute and operation
     and_result = Arithmetic(op="and", src1=a_val, src2=b_val)  # 0xF0 & 0xAA = 0xA0
 
-    # Use czero.eqz: if condition == 0, return and_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return and_result
     selected_and = Arithmetic(op="czero.eqz", src1=and_result, src2=condition)
 
-    # Expected result: since condition≠0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition≠0, should get and_result=0xA0
+    expected = LoadImmediateStep(imm=0xA0)
     assert_equal = AssertEqual(src1=selected_and, src2=expected)
 
     return TestScenario.from_steps(
         id="18",
         name="SID_EXCEP_04_EQZ_FAILING_AND",
-        description="Test czero.eqz with condition≠0 (fails) - returns 0",
+        description="Test czero.eqz with condition≠0 (fails) - returns AND result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -653,27 +653,27 @@ def SID_EXCEP_04_EQZ_FAILING_AND():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_PASSING_XOR():
     """
-    Test czero.eqz with condition=0 (passes) - selects XOR result.
+    Test czero.eqz with condition=0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should pass
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.eqz should return 0
 
     # Compute xor operation
     xor_result = Arithmetic(op="xor", src1=a_val, src2=b_val)  # 0xF0 ^ 0xAA = 0x5A
 
-    # Use czero.eqz: if condition == 0, return xor_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return xor_result
     selected_xor = Arithmetic(op="czero.eqz", src1=xor_result, src2=condition)
 
-    # Expected result: since condition=0, should get xor_result=0x5A
-    expected = LoadImmediateStep(imm=0x5A)
+    # Expected result: since condition=0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_xor, src2=expected)
 
     return TestScenario.from_steps(
         id="19",
         name="SID_EXCEP_04_EQZ_PASSING_XOR",
-        description="Test czero.eqz with condition=0 (passes) - selects XOR result",
+        description="Test czero.eqz with condition=0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -690,27 +690,27 @@ def SID_EXCEP_04_EQZ_PASSING_XOR():
 @zicond_scenario
 def SID_EXCEP_04_EQZ_FAILING_XOR():
     """
-    Test czero.eqz with condition≠0 (fails) - returns 0.
+    Test czero.eqz with condition≠0 (fails) - returns XOR result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should fail
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.eqz should return rs1
 
     # Compute xor operation
     xor_result = Arithmetic(op="xor", src1=a_val, src2=b_val)  # 0xF0 ^ 0xAA = 0x5A
 
-    # Use czero.eqz: if condition == 0, return xor_result, else return 0
+    # Use czero.eqz: if condition == 0, return 0, else return xor_result
     selected_xor = Arithmetic(op="czero.eqz", src1=xor_result, src2=condition)
 
-    # Expected result: since condition≠0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition≠0, should get xor_result=0x5A
+    expected = LoadImmediateStep(imm=0x5A)
     assert_equal = AssertEqual(src1=selected_xor, src2=expected)
 
     return TestScenario.from_steps(
         id="20",
         name="SID_EXCEP_04_EQZ_FAILING_XOR",
-        description="Test czero.eqz with condition≠0 (fails) - returns 0",
+        description="Test czero.eqz with condition≠0 (fails) - returns XOR result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -727,27 +727,27 @@ def SID_EXCEP_04_EQZ_FAILING_XOR():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_PASSING_AND():
     """
-    Test czero.nez with condition≠0 (passes) - selects AND result.
+    Test czero.nez with condition≠0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should pass
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should return 0
 
     # Compute and operation
     and_result = Arithmetic(op="and", src1=a_val, src2=b_val)  # 0xF0 & 0xAA = 0xA0
 
-    # Use czero.nez: if condition != 0, return and_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return and_result
     selected_and = Arithmetic(op="czero.nez", src1=and_result, src2=condition)
 
-    # Expected result: since condition≠0, should get and_result=0xA0
-    expected = LoadImmediateStep(imm=0xA0)
+    # Expected result: since condition≠0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_and, src2=expected)
 
     return TestScenario.from_steps(
         id="21",
         name="SID_EXCEP_04_NEZ_PASSING_AND",
-        description="Test czero.nez with condition≠0 (passes) - selects AND result",
+        description="Test czero.nez with condition≠0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -764,27 +764,27 @@ def SID_EXCEP_04_NEZ_PASSING_AND():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_FAILING_AND():
     """
-    Test czero.nez with condition=0 (fails) - returns 0.
+    Test czero.nez with condition=0 (fails) - returns AND result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should fail
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should return rs1
 
     # Compute and operation
     and_result = Arithmetic(op="and", src1=a_val, src2=b_val)  # 0xF0 & 0xAA = 0xA0
 
-    # Use czero.nez: if condition != 0, return and_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return and_result
     selected_and = Arithmetic(op="czero.nez", src1=and_result, src2=condition)
 
-    # Expected result: since condition=0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition=0, should get and_result=0xA0
+    expected = LoadImmediateStep(imm=0xA0)
     assert_equal = AssertEqual(src1=selected_and, src2=expected)
 
     return TestScenario.from_steps(
         id="22",
         name="SID_EXCEP_04_NEZ_FAILING_AND",
-        description="Test czero.nez with condition=0 (fails) - returns 0",
+        description="Test czero.nez with condition=0 (fails) - returns AND result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -801,27 +801,27 @@ def SID_EXCEP_04_NEZ_FAILING_AND():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_PASSING_XOR():
     """
-    Test czero.nez with condition≠0 (passes) - selects XOR result.
+    Test czero.nez with condition≠0 (passes) - returns 0.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should pass
+    condition = LoadImmediateStep(imm=1)  # condition != 0, so czero.nez should return 0
 
     # Compute xor operation
     xor_result = Arithmetic(op="xor", src1=a_val, src2=b_val)  # 0xF0 ^ 0xAA = 0x5A
 
-    # Use czero.nez: if condition != 0, return xor_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return xor_result
     selected_xor = Arithmetic(op="czero.nez", src1=xor_result, src2=condition)
 
-    # Expected result: since condition≠0, should get xor_result=0x5A
-    expected = LoadImmediateStep(imm=0x5A)
+    # Expected result: since condition≠0, should get 0
+    expected = LoadImmediateStep(imm=0)
     assert_equal = AssertEqual(src1=selected_xor, src2=expected)
 
     return TestScenario.from_steps(
         id="23",
         name="SID_EXCEP_04_NEZ_PASSING_XOR",
-        description="Test czero.nez with condition≠0 (passes) - selects XOR result",
+        description="Test czero.nez with condition≠0 (passes) - returns 0",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -838,27 +838,27 @@ def SID_EXCEP_04_NEZ_PASSING_XOR():
 @zicond_scenario
 def SID_EXCEP_04_NEZ_FAILING_XOR():
     """
-    Test czero.nez with condition=0 (fails) - returns 0.
+    Test czero.nez with condition=0 (fails) - returns XOR result.
     """
     # Input values
     a_val = LoadImmediateStep(imm=0b11110000)  # 0xF0
     b_val = LoadImmediateStep(imm=0b10101010)  # 0xAA
-    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should fail
+    condition = LoadImmediateStep(imm=0)  # condition == 0, so czero.nez should return rs1
 
     # Compute xor operation
     xor_result = Arithmetic(op="xor", src1=a_val, src2=b_val)  # 0xF0 ^ 0xAA = 0x5A
 
-    # Use czero.nez: if condition != 0, return xor_result, else return 0
+    # Use czero.nez: if condition != 0, return 0, else return xor_result
     selected_xor = Arithmetic(op="czero.nez", src1=xor_result, src2=condition)
 
-    # Expected result: since condition=0, should get 0
-    expected = LoadImmediateStep(imm=0)
+    # Expected result: since condition=0, should get xor_result=0x5A
+    expected = LoadImmediateStep(imm=0x5A)
     assert_equal = AssertEqual(src1=selected_xor, src2=expected)
 
     return TestScenario.from_steps(
         id="24",
         name="SID_EXCEP_04_NEZ_FAILING_XOR",
-        description="Test czero.nez with condition=0 (fails) - returns 0",
+        description="Test czero.nez with condition=0 (fails) - returns XOR result",
         env=TestEnvCfg(),
         steps=[
             a_val,
@@ -883,7 +883,6 @@ def SID_EXCEP_04_2_1_MUX_SELECT_0():
     input1 = LoadImmediateStep(imm=0xBEEF)
     selector = LoadImmediateStep(imm=0)  # 0 = select input0, non-zero = select input1
 
-    # MUX implementation using czero operations
     # If selector == 0: use input0, else use 0
     selected_input0 = Arithmetic(op="czero.eqz", src1=input0, src2=selector)
     # If selector != 0: use input1, else use 0
@@ -925,7 +924,6 @@ def SID_EXCEP_04_2_1_MUX_SELECT_1():
     input1 = LoadImmediateStep(imm=0xBEEF)
     selector = LoadImmediateStep(imm=1)  # non-zero = select input1, 0 = select input0
 
-    # MUX implementation using czero operations
     # If selector == 0: use input0, else use 0
     selected_input0 = Arithmetic(op="czero.eqz", src1=input0, src2=selector)
     # If selector != 0: use input1, else use 0


### PR DESCRIPTION
Fixes `Zicond` scenarios that have flipped logic (previously scenarios used conditional assigns value instead of zeros value)